### PR TITLE
Fix for FGS restart in Android 25 (SDK 35)

### DIFF
--- a/qa_sdk/build.gradle
+++ b/qa_sdk/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'kotlinx-serialization'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'com.google.devtools.ksp'
 
-def versionName = '1.1.1-rc05'
-def versionCode = '37'
+def versionName = '1.1.1-rc06'
+def versionCode = '38'
 
 android {
     compileSdk 34


### PR DESCRIPTION
From android 15 a health foreground service can only be started from BOOT/REPLACE receiver. Before we were setting a 1 minute delayed work manager task, but this is not allowed anymore and we need to start the FGS immediately.