### PR TITLE
fix: fixes #26 doesn't retry the signup operation if 403 is returned …

### DIFF
--- a/qa_sdk/src/main/java/com/quantactions/sdk/data/repository/MVPRepository.kt
+++ b/qa_sdk/src/main/java/com/quantactions/sdk/data/repository/MVPRepository.kt
@@ -855,7 +855,7 @@ class MVPRepository @Inject private constructor(
                 // launch a background task to be retried later on.
 
                 Timber.e("ERROR while signup ${apiResponse.errorMessage}")
-                if (apiResponse.httpStatusCode in listOf(424, 404)) {
+                if (apiResponse.httpStatusCode in listOf(424, 404, 403)) {
                     // simply pasted the wrong one
                     throw QASDKException("ParticipationID is invalid")
                 } else { // Network problem


### PR DESCRIPTION
…by the API (id already in use)